### PR TITLE
Compatible for VRCConstraint

### DIFF
--- a/Assets/NatsunekoLaboratory/ConstraintByHumanoid/Editor/ConstraintEditor.cs
+++ b/Assets/NatsunekoLaboratory/ConstraintByHumanoid/Editor/ConstraintEditor.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------
 //  Copyright (c) Natsuneko. All rights reserved.
 //  Licensed under the MIT License. See LICENSE in the project root for license information.
 // ------------------------------------------------------------------------------------------
@@ -10,7 +10,7 @@ using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Animations;
-#if VRC_SDK_Base_2022
+#if VRC_SDK_AVATARS_2022
 using VRC.Dynamics;
 using VRC.SDK3.Dynamics.Constraint.Components;
 #endif
@@ -238,7 +238,7 @@ namespace NatsunekoLaboratory.ConstraintByHumanoid
             if (excludes.Contains(srcGameObject) || excludes.Contains(dstGameObject))
                 return;
 
-#if VRC_SDK_Base_2022
+#if VRC_SDK_AVATARS_2022
             if (dstGameObject.GetComponent(GetTypeFromVrcConstraint(type)) != null)
             {
                 Debug.LogWarning($"The GameObject `{dstGameObject.name}` has been skipped because it already has {type.ToString()}.");
@@ -261,7 +261,7 @@ namespace NatsunekoLaboratory.ConstraintByHumanoid
 #endif
         }
         
-#if VRC_SDK_Base_2022
+#if VRC_SDK_AVATARS_2022
         private static Type GetTypeFromVrcConstraint(Constraint constraint)
         {
             switch (constraint)

--- a/Assets/NatsunekoLaboratory/ConstraintByHumanoid/Editor/ConstraintEditor.cs
+++ b/Assets/NatsunekoLaboratory/ConstraintByHumanoid/Editor/ConstraintEditor.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------
 //  Copyright (c) Natsuneko. All rights reserved.
 //  Licensed under the MIT License. See LICENSE in the project root for license information.
 // ------------------------------------------------------------------------------------------
@@ -7,12 +7,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-
 using UnityEditor;
-
 using UnityEngine;
-using UnityEngine.Animations;
-
+using VRC.Dynamics;
+using VRC.SDK3.Dynamics.Constraint.Components;
 using Object = UnityEngine.Object;
 
 namespace NatsunekoLaboratory.ConstraintByHumanoid
@@ -144,7 +142,7 @@ namespace NatsunekoLaboratory.ConstraintByHumanoid
             var errors = new List<string>();
             if (gameObject.GetComponent<Animator>() == null)
                 errors.Add($"`{gameObject.name}` must have an Animator Component");
-            if (gameObject.GetComponentsInChildren<Transform>().All(w => w.name != "Armature"))
+            if (gameObject.GetComponentsInChildren<Transform>().All(w => w.name.ToLower() != "armature"))
                 errors.Add($"`{gameObject.name}` must have an Armature GameObject as a child");
 
             return errors;
@@ -244,9 +242,9 @@ namespace NatsunekoLaboratory.ConstraintByHumanoid
             }
 
             var constraint = AddConstraintToGameObject(dstGameObject, type);
-            var source = new ConstraintSource { sourceTransform = srcGameObject.transform, weight = 1.0f };
-            constraint.AddSource(source);
-            constraint.constraintActive = true;
+            var source = new VRCConstraintSource { SourceTransform = srcGameObject.transform, Weight = 1.0f };
+            constraint.Sources.Add(source);
+            constraint.ActivateConstraint();
         }
 
         private static Type GetTypeFromConstraint(Constraint constraint)
@@ -254,49 +252,49 @@ namespace NatsunekoLaboratory.ConstraintByHumanoid
             switch (constraint)
             {
                 case Constraint.AimConstraint:
-                    return typeof(AimConstraint);
+                    return typeof(VRCAimConstraint);
 
                 case Constraint.LookAtConstraint:
-                    return typeof(LookAtConstraint);
+                    return typeof(VRCLookAtConstraint);
 
                 case Constraint.ParentConstraint:
-                    return typeof(ParentConstraint);
+                    return typeof(VRCParentConstraint);
 
                 case Constraint.PositionConstraint:
-                    return typeof(PositionConstraint);
+                    return typeof(VRCPositionConstraint);
 
                 case Constraint.RotationConstraint:
-                    return typeof(RotationConstraint);
+                    return typeof(VRCRotationConstraint);
 
                 case Constraint.ScaleConstraint:
-                    return typeof(ScaleConstraint);
+                    return typeof(VRCScaleConstraint);
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(constraint), constraint, null);
             }
         }
 
-        private static IConstraint AddConstraintToGameObject(GameObject obj, Constraint constraint)
+        private static VRCConstraintBase AddConstraintToGameObject(GameObject obj, Constraint constraint)
         {
             switch (constraint)
             {
                 case Constraint.AimConstraint:
-                    return obj.AddComponent<AimConstraint>();
+                    return obj.AddComponent<VRCAimConstraint>();
 
                 case Constraint.LookAtConstraint:
-                    return obj.AddComponent<LookAtConstraint>();
+                    return obj.AddComponent<VRCLookAtConstraint>();
 
                 case Constraint.ParentConstraint:
-                    return obj.AddComponent<ParentConstraint>();
+                    return obj.AddComponent<VRCParentConstraint>();
 
                 case Constraint.PositionConstraint:
-                    return obj.AddComponent<PositionConstraint>();
+                    return obj.AddComponent<VRCPositionConstraint>();
 
                 case Constraint.RotationConstraint:
-                    return obj.AddComponent<RotationConstraint>();
+                    return obj.AddComponent<VRCRotationConstraint>();
 
                 case Constraint.ScaleConstraint:
-                    return obj.AddComponent<ScaleConstraint>();
+                    return obj.AddComponent<VRCScaleConstraint>();
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(constraint), constraint, null);

--- a/Assets/NatsunekoLaboratory/ConstraintByHumanoid/NatsunekoLaboratory.ConstraintByHumanoid.asmdef
+++ b/Assets/NatsunekoLaboratory/ConstraintByHumanoid/NatsunekoLaboratory.ConstraintByHumanoid.asmdef
@@ -1,7 +1,7 @@
 {
     "name": "NatsunekoLaboratory.ConstraintByHumanoid",
+    "rootNamespace": "",
     "references": [],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -10,5 +10,13 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.vrchat.base",
+            "expression": "3.5.0",
+            "define": "VRC_SDK_Base_2022"
+        }
+    ],
+    "noEngineReferences": false
 }

--- a/Assets/NatsunekoLaboratory/ConstraintByHumanoid/NatsunekoLaboratory.ConstraintByHumanoid.asmdef
+++ b/Assets/NatsunekoLaboratory/ConstraintByHumanoid/NatsunekoLaboratory.ConstraintByHumanoid.asmdef
@@ -13,9 +13,9 @@
     "defineConstraints": [],
     "versionDefines": [
         {
-            "name": "com.vrchat.base",
+            "name": "com.vrchat.avatars",
             "expression": "3.5.0",
-            "define": "VRC_SDK_Base_2022"
+            "define": "VRC_SDK_AVATARS_2022"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
# プルリクエストの説明
このプルリクエストでは、ConstraintからVRCConstraintに対応する変更を追加しました。これにより、VRChat向けのConstraintコンポーネントが使用できるようになります。

# 環境
- Unity 2022.3.22f1
- VRChat SDK, Avatar 3.7.5

# 変更内容
ConstraintEditor.cs内で、さまざまな制約タイプに対してVRCConstraintを追加しました。
AimConstraint、LookAtConstraint、ParentConstraint、PositionConstraint、RotationConstraint、およびScaleConstraintに対して、適切なVRCバージョンを対応付けました。
各制約が正しく追加されるよう、関連するロジックを修正しました。

# 動機
VRChatでのアバター改変において、Unity Built-in ConstraintよりVRCConstraintを使用することが安定性や軽量化を踏まえて重要だと考えています。この変更により、ユーザーがより簡単にVRChat向けの制約を設定できるようになります。

# テスト
各VRCConstraintを持つアバターを「Apply Changes」より作成し、動作が期待通りであることを確認しました。各VRCConstraintが正しく機能することを確認しました。

この変更がプロジェクトに役立つことを願っています。ご確認のほどよろしくお願いいたします